### PR TITLE
fix: add missing conventional-changelog-conventional commits dependency for release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,11 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@v4
       env:
@@ -232,5 +237,9 @@ jobs:
       with:
         semantic_version: 19
         extra_plugins: |
+          @semantic-release/commit-analyzer
+          @semantic-release/release-notes-generator
           @semantic-release/changelog
+          @semantic-release/github
           @semantic-release/git
+          conventional-changelog-conventionalcommits

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,13 +3,25 @@
     "main"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
-    "@semantic-release/github",
-    "@semantic-release/git"
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits"
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits"
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    ["@semantic-release/github", {
+      "successComment": false,
+      "failComment": false,
+      "releasedLabels": false
+    }],
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }]
   ],
-  "preset": "conventionalcommits",
   "releaseRules": [
     {"type": "feat", "release": "minor"},
     {"type": "fix", "release": "patch"},


### PR DESCRIPTION
Updated CI release job to inlcude plugins such as conventional-changelog-conventional.